### PR TITLE
Use https://opencode.ai/install (not install.sh)

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -169,7 +169,7 @@ jobs:
 
       - name: Install OpenCode CLI (GitHub-hosted, opencode agent)
         if: vars.RUNNER_TYPE != 'self-hosted' && (vars.AGENT_TYPE || 'codex') == 'opencode'
-        run: curl -fsSL https://opencode.ai/install.sh | bash
+        run: curl -fsSL https://opencode.ai/install | bash
 
       - name: Setup Node.js (GitHub-hosted, codex agent)
         if: vars.RUNNER_TYPE != 'self-hosted' && (vars.AGENT_TYPE || 'codex') == 'codex'

--- a/Makefile
+++ b/Makefile
@@ -321,7 +321,7 @@ init-opencode:
 		echo "OpenCode: $$(opencode --version 2>/dev/null || echo 'installed')"; \
 	else \
 		echo "OpenCode: not found, installing..."; \
-		curl -fsSL https://opencode.ai/install.sh | bash; \
+		curl -fsSL https://opencode.ai/install | bash; \
 	fi
 	@echo ""
 	@echo "Done. Run 'opencode' and use /connect to add providers (e.g., Moonshot for Kimi)."


### PR DESCRIPTION
When I set `AGENT_TYPE` to `opencode`, I found that we need to fix the link to the opencode installation shell script.

Indeed

```sh
$ curl -fsSL https://opencode.ai/install.sh | bash
curl: (56) The requested URL returned error: 404
```

This PR fixes the link to the opencode installation shell script.